### PR TITLE
Removes the ability for a user to right-click and open a context menu.

### DIFF
--- a/content/recording_UI.js
+++ b/content/recording_UI.js
@@ -9,6 +9,16 @@
  **********************************************************************/
 
 var RecordingHandlers = (function _RecordingHandlers() { var pub = {};
+  pub.contextmenuHandler = function _oncontextmenuHandler(event){
+    if (currentlyRecording()){
+      // TODO: scraping tool tip modification
+      // TODO: relation preview modification
+    }
+    pub.updateScraping(event);
+    if (currentlyScraping() && currentlyRecording()){
+      // TODO: scraping modification
+    }
+  }
 
   pub.mouseoverHandler = function _mouseoverHandler(event){
     if (currentlyRecording()){
@@ -99,6 +109,7 @@ var RecordingHandlers = (function _RecordingHandlers() { var pub = {};
 
 return pub;}());
 
+document.addEventListener('contextmenu', RecordingHandlers.contextMenuHandler, true);
 document.addEventListener('mouseover', RecordingHandlers.mouseoverHandler, true);
 document.addEventListener('mouseout', RecordingHandlers.mouseoutHandler, true);
 document.addEventListener('keydown', RecordingHandlers.updateScraping, true);
@@ -250,6 +261,14 @@ var Scraping = (function _Scraping() { var pub = {};
     if (currentlyScraping()){
       event.stopImmediatePropagation();
       event.preventDefault();
+    }
+  }
+
+  document.addEventListener('contextmenu', rerouteContextMenu, true);
+  function rerouteContextMenu(event){
+    if (currentlyScraping()){
+      // TODO: reroute the user to not use the context menu
+      // don't want to record this interaction
     }
   }
 

--- a/content/recording_UI.js
+++ b/content/recording_UI.js
@@ -9,8 +9,9 @@
  **********************************************************************/
 
 var RecordingHandlers = (function _RecordingHandlers() { var pub = {};
-  pub.contextmenuHandler = function _oncontextmenuHandler(event){
+  pub.contextmenuHandler = function _contextmenuHandler(event){
     if (currentlyRecording()){
+      event.preventDefault();
       // TODO: scraping tool tip modification
       // TODO: relation preview modification
     }
@@ -109,7 +110,7 @@ var RecordingHandlers = (function _RecordingHandlers() { var pub = {};
 
 return pub;}());
 
-document.addEventListener('contextmenu', RecordingHandlers.contextMenuHandler, true);
+document.addEventListener('contextmenu', RecordingHandlers.contextmenuHandler, true);
 document.addEventListener('mouseover', RecordingHandlers.mouseoverHandler, true);
 document.addEventListener('mouseout', RecordingHandlers.mouseoutHandler, true);
 document.addEventListener('keydown', RecordingHandlers.updateScraping, true);

--- a/content/recording_UI.js
+++ b/content/recording_UI.js
@@ -265,14 +265,6 @@ var Scraping = (function _Scraping() { var pub = {};
     }
   }
 
-  document.addEventListener('contextmenu', rerouteContextMenu, true);
-  function rerouteContextMenu(event){
-    if (currentlyScraping()){
-      // TODO: reroute the user to not use the context menu
-      // don't want to record this interaction
-    }
-  }
-
   pub.scrapingCriteria = function _scrapingCriteria(event){
     return event.shiftKey && event.altKey; // convention is we need shift+alt+click to scrape
   }


### PR DESCRIPTION
This change prevents users from inadvertently using right-click menus to interfere with the Helena scraping and recording process. The reason this is a problem is that Helena can't record browser interactions, so the right-click menu interaction can't be recorded fully (right-click to open a new tab, for example). Future change will include a description of how to do what they had intended, without a right-click context menu.