### PR TITLE
Implements repeated keypress filter

### DIFF
--- a/content/recording_UI.js
+++ b/content/recording_UI.js
@@ -17,7 +17,13 @@ var RecordingHandlers = (function _RecordingHandlers() { var pub = {};
     if (currentlyRecording()){
       // prevents right click from working
       event.preventDefault();
-      alert("Trying to open a new tab? Try CTRL+Click instead!");
+      if (navigator.appVersion.toLocaleLowerCase().indexOf("win") !== -1) {
+        alert("Trying to open a new tab? Try CTRL+Click instead!");
+      } else if (navigator.appVersion.toLocaleLowerCase().indexOf("mac") !== -1) {
+        alert("Trying to open a new tab? Try CMD+Click instead!");
+      } else { // linux or unix, depends on computer 
+        alert("Trying to open a new tab? Use a keyboard shortcut (like CTRL+CLICK) instead!");
+      }
     }
   }
 

--- a/content/recording_UI.js
+++ b/content/recording_UI.js
@@ -263,13 +263,17 @@ var Scraping = (function _Scraping() { var pub = {};
 
   let currKeyState = {}; // keeps track of the keys that are currently being pressed down
 
-  // Because Windows has this habit of recording multiple events for a continued 
-  // key press or key down, we want to throw out events that are repeats of events
+  // Because Windows has this habit of producing multiple keypress, keydown events 
+  // for a continued key press, we want to throw out events that are repeats of events
   // we've already seen. This change fixes a major issue with running Helena
-  // on Windows, in that scraping gets hung up on all the key presses instead
-  // of gathering data really fast. 
+  // on Windows, in that the top-level tool chooses to ignore events that can be
+  // accomplished without running Ringer (e.g. scraping relation items), but keydown
+  // events can only be accomplished by Ringer.  So replay gets slow because of having to
+  // replay all the Ringer events for each row of the relation.
+  // note: if we run into issues where holding a key down in a recording produces a bad replay,
+  // look here first
   additional_recording_filters.ignoreExtraKeydowns = function(eventData){
-    if (eventData.type === "keypress" || eventData.type === "keydown") { // for now, we'll ignore multiple key presses for all keys (not just ctrl and alt)
+    if (eventData.type === "keypress" || eventData.type === "keydown") { // for now, we'll ignore multiple keypresses for all keys (not just ctrl and alt)
       if (!currKeyState[eventData.keyCode]) { // first seen, record that it's being pressed down
         currKeyState[eventData.keyCode] = true;
         return false;


### PR DESCRIPTION
This filter keeps repeated but non-unique keypresses from being recorded as unique events. This is in response to an issue found on Windows computers, where holding a key down is recorded as many events, not just one (like on UNIX machines), which caused a lot of replay issues. By adding this filter, an effective recording can be made on Windows computers as were previously made on UNIX machines.  