### PR TITLE
content: set exclude first and last

### DIFF
--- a/content/relation_finding.js
+++ b/content/relation_finding.js
@@ -138,7 +138,7 @@ var RelationFinder = (function _RelationFinder() { var pub = {};
   // feature_dict is the primary part of our selector
   // exclude_first tells us whether to skip the first row, as we often do when we have headers
   // suffixes tell us how to find subcomponents of a row in the relation
-  pub.interpretRelationSelectorHelper = function _interpretRelationSelectorHelper(feature_dict, exclude_first){
+  pub.interpretRelationSelectorHelper = function _interpretRelationSelectorHelper(feature_dict, exclude_first, exclude_last){
     // WALconsole.log("interpretRelationSelectorHelper", feature_dict, exclude_first, subcomponents_function);
     var candidates = getAllCandidates();
     var listOfRowNodes = [];
@@ -160,15 +160,22 @@ var RelationFinder = (function _RelationFinder() { var pub = {};
       }
     }
     /* mariaSlice */
+    /* maria question --> do we want to just take the min of exclude_first and length? */
+    //  if we try to exclude the first 4 from size 3, should we just remove all?
     if (exclude_first > 0 && listOfRowNodes.length > exclude_first){
-      return listOfRowNodes.slice(exclude_first,listOfRowNodes.length);
+      listOfRowNodes = listOfRowNodes.slice(exclude_first,listOfRowNodes.length);
     }
+
+    if (exclude_last > 0 && listOfRowNodes.length > exclude_last) {
+      listOfRowNodes = listOfRowNodes.slice(0, listOfRowNodes.length - exclude_last);
+    }
+
     WALconsole.log("listOfRowNodes", listOfRowNodes);
     return listOfRowNodes;
   };
 
 
-  pub.interpretTableSelectorHelper = function _interpretTableSelectorHelper(featureDict, excludeFirst){
+  pub.interpretTableSelectorHelper = function _interpretTableSelectorHelper(featureDict, excludeFirst, excludeLast){
     // we don't use this for nested tables!  this is just for very simple tables, otherwise we'd graduate to the standard approach
     var nodes = xPathToNodes(featureDict.xpath);
     var table = null;
@@ -198,6 +205,7 @@ var RelationFinder = (function _RelationFinder() { var pub = {};
 
     var rows = table.find("tr");
     rows = rows.slice(excludeFirst, rows.length);  // mariaSlice
+    rows = rows.slice(0, rows.length - excludeLast);
     return rows;
   };
 
@@ -224,10 +232,10 @@ var RelationFinder = (function _RelationFinder() { var pub = {};
 
     if (selector.selector.table === true){
       // let's go ahead and sidetrack off to the table extraction routine
-      return [pub.interpretTableSelectorHelper(selector.selector, selector.exclude_first)];
+      return [pub.interpretTableSelectorHelper(selector.selector, selector.exclude_first, selector.exclude_last)];
     }
     // else the normal case with the normal extractor
-    return [pub.interpretRelationSelectorHelper(selector.selector, selector.exclude_first)];
+    return [pub.interpretRelationSelectorHelper(selector.selector, selector.exclude_first, selector.exclude_last)]; 
   };
 
   pub.interpretRelationSelectorCellNodes = function _interpretRelationSelectorCellNodes(selector, rowNodeLists){
@@ -315,6 +323,7 @@ var RelationFinder = (function _RelationFinder() { var pub = {};
       var optionNodes = pub.interpretPulldownSelector(selector.selector); // todo: ugh, gross that we descend here butnot in the above
       console.log("selector.exclude_first", selector.exclude_first);
       optionNodes = optionNodes.splice(selector.exclude_first, optionNodes.length); // mariaSlice
+      optionNodes = optionNodes.splice(0, optionNodes.length - selector.exclude_last);
       var cells = _.map(optionNodes, function(o){return [o];});
       // a wrapper function that goes through and tosses cells/rows that are display:none
       cells = onlyDisplayedCellsAndRows(cells);
@@ -408,17 +417,13 @@ var RelationFinder = (function _RelationFinder() { var pub = {};
     return columns;
   }
 
+  // sets exclude last value to 0
   function Selector(dict, exclude_first, columns, positive_nodes, negative_nodes){
-    return {selector: dict, 
-              exclude_first: exclude_first, 
-              columns: columns, 
-              positive_nodes: positive_nodes, 
-              negative_nodes: negative_nodes,
-              selector_version: 1}; // this form of Selector object should only be used for version 1 selectors, or else change this
+    return NewSelector(dict, exclude_first, 0, columns, positive_nodes, negative_nodes); // this form of Selector object should only be used for version 1 selectors, or else change this
   }
 
   // new function, but keep old one around just in case
-  function Selector(dict, exclude_first, exclude_last, positive_nodes, negative_nodes) {
+  function NewSelector(dict, exclude_first, exclude_last, columns, positive_nodes, negative_nodes) {
     return {selector: dict, 
       exclude_first: exclude_first, 
       exclude_last: exclude_last,
@@ -440,7 +445,7 @@ var RelationFinder = (function _RelationFinder() { var pub = {};
     //if (feature_dict.hasOwnProperty("tag") && feature_dict["tag"].length > 1 && features !== all_features){
     //  return synthesizeSelector(all_features);
     //}
-    var rows = pub.interpretRelationSelector(Selector(feature_dict, false, columns));
+    var rows = pub.interpretRelationSelector(Selector(feature_dict, 0, columns));
     
     //now handle negative examples
     var exclude_first = 0;
@@ -450,7 +455,7 @@ var RelationFinder = (function _RelationFinder() { var pub = {};
         var node = nodes[i];
         if (_.contains(negative_nodes, node)){
           if (j === 0){
-            exclude_first = 1;
+            exclude_first = 1; // maria question: do we ever need to worry about setting exclude_last here?
           }
           else if (features !== almost_all_features) {
             //xpaths weren't enough to exclude nodes we need to exclude
@@ -661,7 +666,7 @@ var RelationFinder = (function _RelationFinder() { var pub = {};
       }
       var featureDict = tableFeatureDict(tableParent);
       var cellNodes = _.union($(tr).find("td, th").toArray(), rowNodes); // we'll make columns for each argument node of course, but let's also do all the td elements
-      var selector = Selector(featureDict, index, columnsFromNodeAndSubnodes(tr, cellNodes), rowNodes, []);
+      var selector = Selector(featureDict, index, columnsFromNodeAndSubnodes(tr, cellNodes), rowNodes, []); // mia here this is also fine
       var relation = pub.interpretRelationSelector(selector);
       selector.relation = relation;
       var score = relation.length * relation[0].length;
@@ -868,6 +873,7 @@ var RelationFinder = (function _RelationFinder() { var pub = {};
       var optionsRelation = extractOptionsRelationFromSelectorNode(node);
       var firstRowXpath = optionsRelation[0][0].xpath;
       var excludeFirst = 0; // convenient to always use 0 so we can correctly index into the relation
+      var excludeLast = 0;
       optionsRelation = optionsRelation.splice(excludeFirst, optionsRelation.length);
 
       newMsg.relation_id = null;
@@ -876,6 +882,7 @@ var RelationFinder = (function _RelationFinder() { var pub = {};
       newMsg.next_type = NextTypes.NONE;
       newMsg.next_button_selector = null;
       newMsg.exclude_first = excludeFirst; // todo: can we do better?  extra recording info?
+      newMsg.exclude_last = excludeLast; // maria --> right now, unconditionally set to 0
       newMsg.num_rows_in_demonstration = options.length;
       newMsg.selector = {type: "pulldown", index: index};
       newMsg.selector_version = 2; // 2 is for pulldown selectors?
@@ -979,7 +986,7 @@ var RelationFinder = (function _RelationFinder() { var pub = {};
         if (rel === null){
           continue;
         }
-        var selector_obj = Selector(rel.selector, rel.exclude_first, rel.columns);
+        var selector_obj = NewSelector(rel.selector, rel.exclude_first, rel.exclude_last, rel.columns); // mia here problem, need to give rel.exclude_last
         selector_obj.selector_version = rel.selector_version;
         var relationNodes = pub.interpretRelationSelector(selector_obj);
         if (relationNodes.length === 0){
@@ -1040,6 +1047,7 @@ var RelationFinder = (function _RelationFinder() { var pub = {};
     }
     WALconsole.log("currBestSelector", currBestSelector);
     newMsg.exclude_first = currBestSelector.exclude_first;
+    newMsg.exclude_last = currBestSelector.exclude_last;
     newMsg.num_rows_in_demonstration = currBestSelector.relation.length;
     newMsg.selector = currBestSelector.selector;
     newMsg.selector_version = 1; // right now they're all 1.  someday may want to be able to add new versions of selectors that are processed differently

--- a/content/setup.js
+++ b/content/setup.js
@@ -33,6 +33,8 @@ utilities.listenForMessage("mainpanel", "content", "backButton", function(){hist
 utilities.listenForMessage("mainpanel", "content", "pageStats", function(){ utilities.sendMessage("content", "mainpanel", "pageStats", {"numNodes": $('*').length});});
 utilities.listenForMessage("mainpanel", "content", "runNextInteraction", function(msg){RelationFinder.runNextInteraction(msg);});
 utilities.listenForMessage("mainpanel", "content", "currentColumnIndex", function(msg){RelationFinder.setEditRelationIndex(msg.index);});
+utilities.listenForMessage("mainpanel", "content", "excludeFirstRows", function(msg){RelationFinder.setExcludeFirst(msg.numRows);});
+utilities.listenForMessage("mainpanel", "content", "excludeLastRows", function(msg){RelationFinder.setExcludeLast(msg.numRows);});
 
 utilities.listenForFrameSpecificMessage("mainpanel", "content", "likelyRelation",
 	function (msg, sendResponse){

--- a/mainpanel/helena.js
+++ b/mainpanel/helena.js
@@ -4056,7 +4056,7 @@ var WebAutomationLanguage = (function _WebAutomationLanguage() {
   }
 
   var relationCounter = 0;
-  pub.Relation = function _Relation(relationId, name, selector, selectorVersion, excludeFirst, columns, demonstrationTimeRelation, numRowsInDemo, pageVarName, url, nextType, nextButtonSelector, frame){
+  pub.Relation = function _Relation(relationId, name, selector, selectorVersion, excludeFirst, excludeLast, columns, demonstrationTimeRelation, numRowsInDemo, pageVarName, url, nextType, nextButtonSelector, frame){
     Revival.addRevivalLabel(this);
     var doInitialization = selector;
     if (doInitialization){ // we will sometimes initialize with undefined, as when reviving a saved program
@@ -4064,6 +4064,7 @@ var WebAutomationLanguage = (function _WebAutomationLanguage() {
       this.selector = selector;
       this.selectorVersion = selectorVersion;
       this.excludeFirst = excludeFirst;
+      this.excludeLast = excludeLast;
       this.columns = columns;
       this.demonstrationTimeRelation = demonstrationTimeRelation;
       this.numRowsInDemo = numRowsInDemo;
@@ -4202,10 +4203,11 @@ var WebAutomationLanguage = (function _WebAutomationLanguage() {
       initialize();
     }
 
-    this.setNewAttributes = function _setNewAttributes(selector, selectorVersion, excludeFirst, columns, demonstrationTimeRelation, numRowsInDemo, nextType, nextButtonSelector){
+    this.setNewAttributes = function _setNewAttributes(selector, selectorVersion, excludeFirst, excludeLast, columns, demonstrationTimeRelation, numRowsInDemo, nextType, nextButtonSelector){
       this.selector = selector;
       this.selectorVersion = selectorVersion;
       this.excludeFirst = excludeFirst;
+      this.excludeLast = excludeLast;
       this.demonstrationTimeRelation = demonstrationTimeRelation;
       this.numRowsInDemo = numRowsInDemo;
       this.nextType = nextType;
@@ -4278,8 +4280,8 @@ var WebAutomationLanguage = (function _WebAutomationLanguage() {
       return false;
     };
 
-    this.messageRelationRepresentation = function _messageRelationRepresentation(){
-      return {id: this.id, name: this.name, selector: this.selector, selector_version: this.selectorVersion, exclude_first: this.excludeFirst, columns: this.columns, next_type: this.nextType, next_button_selector: this.nextButtonSelector, url: this.url, num_rows_in_demonstration: this.numRowsInDemo};
+    this.messageRelationRepresentation = function _messageRelationRepresentation(){ // maria here problem
+      return {id: this.id, name: this.name, selector: this.selector, selector_version: this.selectorVersion, exclude_first: this.excludeFirst, exclude_last: this.excludeLast, columns: this.columns, next_type: this.nextType, next_button_selector: this.nextButtonSelector, url: this.url, num_rows_in_demonstration: this.numRowsInDemo};
     };
 
     this.noMoreRows = function _noMoreRows(runObject, pageVar, callback, prinfo, allowMoreNextInteractions){
@@ -6906,7 +6908,7 @@ var WebAutomationLanguage = (function _WebAutomationLanguage() {
       else{
         // if we have a normal selector, let's add that to our set of relations
         if (data.selector){
-          var rel = new WebAutomationLanguage.Relation(data.relation_id, data.name, data.selector, data.selector_version, data.exclude_first, data.columns, data.first_page_relation, data.num_rows_in_demonstration, data.page_var_name, data.url, data.next_type, data.next_button_selector, data.frame);
+          var rel = new WebAutomationLanguage.Relation(data.relation_id, data.name, data.selector, data.selector_version, data.exclude_first, data.exclude_last, data.columns, data.first_page_relation, data.num_rows_in_demonstration, data.page_var_name, data.url, data.next_type, data.next_button_selector, data.frame);
           this.relations.push(rel);
           this.relations = _.uniq(this.relations);
         }
@@ -6914,7 +6916,7 @@ var WebAutomationLanguage = (function _WebAutomationLanguage() {
         if (data.pulldown_relations){
           for (var i = 0; i < data.pulldown_relations.length; i++){
             var relMsg = data.pulldown_relations[i];
-            var rel = new WebAutomationLanguage.Relation(relMsg.relation_id, relMsg.name, relMsg.selector, relMsg.selector_version, relMsg.exclude_first, relMsg.columns, relMsg.first_page_relation, relMsg.num_rows_in_demonstration, relMsg.page_var_name, relMsg.url, relMsg.next_type, relMsg.next_button_selector, relMsg.frame);
+            var rel = new WebAutomationLanguage.Relation(relMsg.relation_id, relMsg.name, relMsg.selector, relMsg.selector_version, relMsg.exclude_first, relMsg.exclude_last, relMsg.columns, relMsg.first_page_relation, relMsg.num_rows_in_demonstration, relMsg.page_var_name, relMsg.url, relMsg.next_type, relMsg.next_button_selector, relMsg.frame);
             this.relations.push(rel);
             this.relations = _.uniq(this.relations);
           }


### PR DESCRIPTION
Modifies selector and relation to store the number of rows to exclude from the end of the table. Adds listeners to content script for set exclude first and last messages from mainpanel. Upon receiving set exclude first or last messages, updates the selector and slices the relation before sending the message back to mainpanel to update the UI.